### PR TITLE
Add multiple filters, custom conditions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "ical-filter"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -836,6 +836,7 @@ dependencies = [
  "env_logger",
  "ical",
  "ics",
+ "regex",
  "serde",
  "serde_json",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,6 +494,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d0e2d24e5ee3b23a01de38eefdcd978907890701f08ffffd4cb457ca4ee8d6"
+
+[[package]]
 name = "derive_more"
 version = "0.99.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,6 +846,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serde_qs",
 ]
 
 [[package]]
@@ -1420,6 +1427,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_qs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9408a61dabe404c76cec504ec510f7d92f41dc0a9362a0db8ab73d141cfbf93f"
+dependencies = [
+ "actix-web",
+ "data-encoding",
+ "futures",
+ "percent-encoding",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,6 +1528,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,6 +836,7 @@ dependencies = [
  "env_logger",
  "ical",
  "ics",
+ "listenfd",
  "regex",
  "serde",
  "serde_json",
@@ -936,6 +937,17 @@ name = "linked-hash-map"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
+
+[[package]]
+name = "listenfd"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "492158e732f2e2de81c592f0a2427e57e12cd3d59877378fe7af624b6bbe0ca1"
+dependencies = [
+ "libc",
+ "uuid",
+ "winapi 0.3.8",
+]
 
 [[package]]
 name = "lock_api"
@@ -1675,6 +1687,15 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "uuid"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ical-filter"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Wouter Geraedts <git@woutergeraedts.nl>"]
 edition = "2018"
 description = "HTTP daemon to normalize and filter iCalendar files"
@@ -27,3 +27,4 @@ ical = "0.6.0"
 
 serde = "1.0.114"
 serde_json = "1.0.55"
+regex = "1.3.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ ical = "0.6.0"
 
 serde = "1.0.114"
 serde_json = "1.0.55"
+serde_qs = { version = "0.7.0", features = ["actix"] }
+
 regex = "1.3.9"
 listenfd = "0.3.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,7 @@ ical = "0.6.0"
 serde = "1.0.114"
 serde_json = "1.0.55"
 regex = "1.3.9"
+listenfd = "0.3.3"
+
+[features]
+clippy = []

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ cargo run
 All endpoints accept the following query parameters:
 
 * `url`: source url for an ical feed.
-* `filter` *(optional)*: tilde (~) delimited list of filters of the format
+* `filter[]` *(optional)*: a filter of the format
   `[!]condition:pattern` to be applied on the summary (title) field.
   Including a `!` at the start of the filter will invert it. All filters must
   match for an event to be included.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,23 @@ cargo run
 All endpoints accept the following query parameters:
 
 * `url`: source url for an ical feed.
-* `filter` *(optional)*: whitelist filter for summary field of events. Can only set one (for now).
+* `filter` *(optional)*: tilde (~) delimited list of filters of the format
+  `[!]condition:pattern` to be applied on the summary (title) field.
+  Including a `!` at the start of the filter will invert it. All filters must
+  match for an event to be included.
+
+Supported conditions:
+* `equals` -- summary equals `pattern` (the behaviour of previous versions)
+* `startsWith` -- summary starts with `pattern`
+* `endsWith` -- summary ends with `pattern`
+* `contains` -- summary contains `pattern`
+* `true` -- always matches, `pattern` unused
+* `regex` -- summary matches the given regex
+
+Example filters:
+* `true:` -- matches everything. equivalent to not including a filter
+* `!regex:this:can:have:colons.*` -- rejects events starting with `this:can:have:colons`
+* `contains:aaa~!true:` -- rejects all events due to the inverted `true` condition
 
 ### JSON
 Retrieve the `url` and render as JSON with `Content-Type: application/json`.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Supported conditions:
 * `startsWith` -- summary starts with `pattern`
 * `endsWith` -- summary ends with `pattern`
 * `contains` -- summary contains `pattern`
-* `true` -- always matches, `pattern` unused
 * `regex` -- summary matches the given regex
 
 Example filters:

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,7 @@ pub enum Error {
     UpstreamFailure,
     AuthenticationFailure,
     Inconsistency,
+    BadRequest(String),
 }
 
 impl core::convert::From<SendRequestError> for Error {
@@ -33,6 +34,12 @@ impl core::convert::From<chrono::format::ParseError> for Error {
     }
 }
 
+impl core::convert::From<serde_qs::Error> for Error {
+    fn from(e: serde_qs::Error) -> Self {
+        Error::BadRequest(format!("{}", e))
+    }
+}
+
 pub type Result<T> = core::result::Result<T, Error>;
 
 impl core::fmt::Display for Error {
@@ -47,6 +54,7 @@ impl ResponseError for Error {
             Error::UpstreamFailure => HttpResponse::ServiceUnavailable(),
             Error::AuthenticationFailure => HttpResponse::InternalServerError(),
             Error::Inconsistency => HttpResponse::InternalServerError(),
+            Error::BadRequest(_) => HttpResponse::BadRequest(),
         };
 
         response.json(self)

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,0 +1,139 @@
+use regex::Regex;
+use serde::de;
+use std::fmt;
+
+type MyError = Box<dyn std::error::Error>;
+
+pub const TRUE_FILTER: Filter = Filter {
+    invert: false,
+    operator: FilterOperator::True,
+};
+
+#[derive(Debug)]
+enum FilterOperator {
+    Equals(String),
+    StartsWith(String),
+    EndsWith(String),
+    Contains(String),
+    True,
+    Regex(Regex),
+}
+
+#[derive(Debug)]
+pub struct Filter {
+    invert: bool,
+    operator: FilterOperator,
+}
+
+impl FilterOperator {
+    /// Parses a stringified filter operator into a [`FilterOperator`](enum.FilterOperator.html)
+    fn parse(s: &str, content: String) -> Result<FilterOperator, MyError> {
+        match s {
+            "equals" => Ok(FilterOperator::Equals(content)),
+            "startsWith" => Ok(FilterOperator::StartsWith(content)),
+            "endsWith" => Ok(FilterOperator::EndsWith(content)),
+            "contains" => Ok(FilterOperator::Contains(content)),
+            "true" => Ok(FilterOperator::True),
+            "regex" => Ok(FilterOperator::Regex(Regex::new(&content)?)),
+            _ => Err("unknown filter operator; options are equals, startsWith, endsWith, contains, true, regex".into()),
+        }
+    }
+
+    /// Execute the filter operator on the given string. Returns whether it
+    /// matches.
+    fn matches(&self, s: &str) -> bool {
+        match self {
+            FilterOperator::Equals(pat) => s == pat,
+            FilterOperator::StartsWith(pat) => s.starts_with(pat),
+            FilterOperator::EndsWith(pat) => s.ends_with(pat),
+            FilterOperator::Contains(pat) => s.contains(pat),
+            FilterOperator::True => true,
+            FilterOperator::Regex(pat) => pat.is_match(s),
+        }
+    }
+}
+
+impl Filter {
+    /// Parses a filter into a Filter struct.
+    fn parse(s: &str) -> Result<Filter, MyError> {
+        let invert = s.starts_with('!');
+        let s = if invert { &s[1..] } else { s };
+
+        let colon = s.find(":").ok_or_else(|| "missing colon in filter")?;
+        let (operator, text) = s.split_at(colon);
+        // chop off colon
+        let text = &text[1..];
+        let operator = FilterOperator::parse(operator, text.to_owned())?;
+        Ok(Filter { invert, operator })
+    }
+
+    /// Execute the filter on the given string. Returns whether it matches.
+    pub fn matches(&self, s: &str) -> bool {
+        let result = self.operator.matches(s);
+        if self.invert {
+            !result
+        } else {
+            result
+        }
+    }
+}
+
+pub fn deserialize_filter_list<'de, D>(ds: D) -> Result<Option<Vec<Filter>>, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    // inspired by https://github.com/actix/actix-web/issues/1301#issuecomment-687041548
+    struct StringVecVisitor;
+
+    impl<'de> de::Visitor<'de> for StringVecVisitor {
+        type Value = Option<Vec<Filter>>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            // tilde arbitrarily chosen as it is very unlikely to appear in a filter
+            formatter.write_str("a tilde separated list of [!]operator:filter")
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            let mut filters = Vec::new();
+            for filt in v.split("~") {
+                let parsed = Filter::parse(filt).map_err(E::custom)?;
+                filters.push(parsed);
+            }
+
+            Ok(Some(filters))
+        }
+    }
+
+    ds.deserialize_any(StringVecVisitor)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_load_filter() {
+        let qs = "startsWith:aaa";
+        let parsed = Filter::parse(qs).unwrap();
+        assert_eq!(parsed.invert, false);
+        assert!(matches!(
+            parsed.operator,
+            FilterOperator::StartsWith(a) if a == "aaa"
+        ));
+
+        let qs = "true:aaa";
+        let parsed = Filter::parse(qs).unwrap();
+        assert_eq!(parsed.invert, false);
+        assert!(matches!(parsed.operator, FilterOperator::True));
+        assert!(parsed.matches("a"));
+
+        let qs = "!true:aaa";
+        let parsed = Filter::parse(qs).unwrap();
+        assert_eq!(parsed.invert, true);
+        assert!(matches!(parsed.operator, FilterOperator::True));
+        assert!(!parsed.matches("a"));
+    }
+}


### PR DESCRIPTION
This is a breaking change for existing installations, and I bumped the version accordingly.

Exact syntax absolutely up to bikeshedding, however, the tilde separator was chosen as it would be very uncommon in event names, regexes, *and* can be included in URLs without any URL encoding.

I initially needed this change set to be able to invert conditions, but figured since I needed to hack on it anyway, I could make the matching powerful.